### PR TITLE
Added Seq and Seq? builtin functions and changes to fix Sequence tests errors

### DIFF
--- a/runtime/builtin/except.ts
+++ b/runtime/builtin/except.ts
@@ -1,6 +1,6 @@
 import { toStr } from "../ops";
 import { SuObject } from "../suobject";
-import { global } from "../global";
+import { globalLookup } from "../global";
 import { Strings } from "./strings";
 const sm: any = Strings.prototype;
 import * as util from "../utility";
@@ -21,7 +21,7 @@ export class Except extends String {
     }
 
     lookup(this: any, method: string): SuCallable {
-        return this[method] || sm[method] || global('Strings')[method];
+        return this[method] || sm[method] || globalLookup('Strings', method);
     }
 
     // BUILT-IN METHODS

--- a/runtime/builtin/seq.ts
+++ b/runtime/builtin/seq.ts
@@ -1,0 +1,127 @@
+import { SuIterable } from "../suvalue";
+import { maxargs } from "../su";
+import { add } from "../ops";
+import { cmp } from "../cmp";
+import { SuSequence, SequenceBase } from "./susequence";
+import { SuObject } from "../suobject";
+import * as util from "../utility";
+
+class SuSeq extends SuIterable {
+    private infinite: boolean = false;
+    private i: any;
+    constructor(private from: any, private to: any, private by: any) {
+        super();
+        if (from === false) {
+            this.infinite = true;
+            this.from = 0;
+            this.to = Number.MAX_SAFE_INTEGER;
+        } else if (to === false) {
+            this.to = this.from;
+            this.from = 0;
+        }
+        this.i = from;
+    }
+
+    public toString(): string {
+        return this.infinite
+            ? "Seq()"
+            : `Seq(${this.from}, ${this.to}, ${this.by})`;
+    }
+
+    public Next(): any {
+        maxargs(0, arguments.length);
+        if (cmp(this.i, this.to) >= 0)
+            return this;
+        let x = this.i;
+        this.i = add(this.i, this.by);
+        return x;
+    }
+
+    public Dup(): SuIterable {
+        maxargs(0, arguments.length);
+        return this.infinite
+            ? new SuSeq(false, false, this.by)
+            : new SuSeq(this.from, this.to, this.by);
+    }
+
+    public ['Infinite?'](): boolean {
+        maxargs(0, arguments.length);
+        return this.infinite;
+    }
+
+    public type(): string {
+        return 'SeqIter';
+    }
+}
+
+export function su_seq(from: any = false, to: any = false, by: any = 1) {
+    maxargs(3, arguments.length);
+    return new SuSequence(new SuSeq(from, to, by));
+}
+
+export function su_seqq(x: any): boolean {
+    maxargs(1, arguments.length);
+    return x instanceof SequenceBase;
+}
+
+//BUILTIN Seq(from=false, to=false, by=1)
+//GENERATED start
+(su_seq as any).$call = su_seq;
+(su_seq as any).$callNamed = function ($named: any, from: any, to: any, by: any) {
+    ({ from = from, to = to, by = by } = $named);
+    return su_seq(from, to, by);
+};
+(su_seq as any).$callAt = function (args: SuObject) {
+    return (su_seq as any).$callNamed(util.mapToOb(args.map), ...args.vec);
+};
+(su_seq as any).$params = 'from=false, to=false, by=1';
+//GENERATED end
+
+//BUILTIN Seq?(value)
+//GENERATED start
+(su_seqq as any).$call = su_seqq;
+(su_seqq as any).$callNamed = function ($named: any, value: any) {
+    ({ value = value } = $named);
+    return su_seqq(value);
+};
+(su_seqq as any).$callAt = function (args: SuObject) {
+    return (su_seqq as any).$callNamed(util.mapToOb(args.map), ...args.vec);
+};
+(su_seqq as any).$params = 'value';
+//GENERATED end
+
+//BUILTIN SuSeq.Next()
+//GENERATED start
+(SuSeq.prototype['Next'] as any).$call = SuSeq.prototype['Next'];
+(SuSeq.prototype['Next'] as any).$callNamed = function (_named: any) {
+    return SuSeq.prototype['Next'].call(this);
+};
+(SuSeq.prototype['Next'] as any).$callAt = function (args: SuObject) {
+    return (SuSeq.prototype['Next'] as any).$callNamed.call(this, util.mapToOb(args.map), ...args.vec);
+};
+(SuSeq.prototype['Next'] as any).$params = '';
+//GENERATED end
+
+//BUILTIN SuSeq.Dup()
+//GENERATED start
+(SuSeq.prototype['Dup'] as any).$call = SuSeq.prototype['Dup'];
+(SuSeq.prototype['Dup'] as any).$callNamed = function (_named: any) {
+    return SuSeq.prototype['Dup'].call(this);
+};
+(SuSeq.prototype['Dup'] as any).$callAt = function (args: SuObject) {
+    return (SuSeq.prototype['Dup'] as any).$callNamed.call(this, util.mapToOb(args.map), ...args.vec);
+};
+(SuSeq.prototype['Dup'] as any).$params = '';
+//GENERATED end
+
+//BUILTIN SuSeq.Infinite?()
+//GENERATED start
+(SuSeq.prototype['Infinite?'] as any).$call = SuSeq.prototype['Infinite?'];
+(SuSeq.prototype['Infinite?'] as any).$callNamed = function (_named: any) {
+    return SuSeq.prototype['Infinite?'].call(this);
+};
+(SuSeq.prototype['Infinite?'] as any).$callAt = function (args: SuObject) {
+    return (SuSeq.prototype['Infinite?'] as any).$callNamed.call(this, util.mapToOb(args.map), ...args.vec);
+};
+(SuSeq.prototype['Infinite?'] as any).$params = '';
+//GENERATED end

--- a/runtime/builtin/strings.ts
+++ b/runtime/builtin/strings.ts
@@ -7,10 +7,11 @@ import { mandatory, maxargs } from "../args";
 import { Result, ForEach, Regex } from "../regex";
 import { RegexReplace} from "../regexreplace";
 import { SuIterable } from "../suvalue";
-import { toInt, toStr, toBoolean } from "../ops";
+import { toInt, toStr, toBoolean, isString } from "../ops";
 
 export function su_stringq(x: any): boolean {
-    return typeof x === 'string';
+    maxargs(1, arguments.length);
+    return isString(x);
 }
 //BUILTIN String?(value)
 //GENERATED start

--- a/runtime/global.ts
+++ b/runtime/global.ts
@@ -15,6 +15,13 @@ export function global(name: string) {
     return x;
 }
 
+export function globalLookup(name: string, method: string) {
+    let cl = global(name);
+    if (cl.hasOwnProperty(method))
+        return cl[method];
+    return null;
+}
+
 export function tryGlobal(name: string) {
     try {
         return global(name);

--- a/runtime/globals.ts
+++ b/runtime/globals.ts
@@ -46,6 +46,10 @@ defGlobal('Number?', su_numberq);
 import { su_sequence } from "./builtin/susequence";
 defGlobal('Sequence', su_sequence);
 
+import { su_seq, su_seqq } from "./builtin/seq";
+defGlobal('Seq', su_seq);
+defGlobal('Seq?', su_seqq);
+
 /** FOR TESTING PURPOSES ONLY! */
 defGlobal('Def', su_def);
 function su_def(global: string, value: any): any {

--- a/runtime/ops.ts
+++ b/runtime/ops.ts
@@ -12,6 +12,10 @@ export function is(x: any, y: any): boolean {
     return false;
 }
 
+export function isnt(x: any, y: any): boolean {
+    return !is(x, y);
+}
+
 export function isString(x: any): boolean {
     return x != null && typeof x.valueOf() === 'string';
 }
@@ -54,8 +58,91 @@ export function toInt(x: any): number {
     return value;
 }
 
+export type Num = number | SuNum;
+export function toNum(x: any): Num {
+    if (typeof x === 'number' || x instanceof SuNum)
+        return x;
+    if (x === false || x === "")
+        return 0;
+    if (x === true)
+        return 1;
+    if (isString(x)) {
+        if (!/[.eE]/.test(x) && x.length < 14)
+            return parseInt(x);
+        let n = SuNum.parse(x);
+        if (n)
+            return n;
+    }
+    throw new Error("can't convert " + type(x) + " to number");
+}
+
+export function toSuNum(x: number | SuNum): SuNum {
+    return (typeof x === 'number') ? SuNum.make(x) : x;
+}
+
 export function toBoolean(x: any): boolean {
     if (typeof x === 'boolean')
         return x;
     throw new Error("expected boolean, got " + type(x));
+}
+
+export function add(x: any, y: any): Num {
+    x = toNum(x);
+    y = toNum(y);
+    if (typeof x === 'number' && typeof y === 'number')
+        return x + y;
+    else
+        return SuNum.add(toSuNum(x), toSuNum(y));
+}
+
+export function sub(x: any, y: any): Num {
+    x = toNum(x);
+    y = toNum(y);
+    if (typeof x === 'number' && typeof y === 'number')
+        return x - y;
+    else
+        return SuNum.sub(toSuNum(x), toSuNum(y));
+}
+
+export function mul(x: any, y: any): Num {
+    x = toNum(x);
+    y = toNum(y);
+    if (typeof x === 'number' && typeof y === 'number')
+        return x * y;
+    else
+        return SuNum.mul(toSuNum(x), toSuNum(y));
+}
+
+export function div(x: any, y: any): SuNum {
+    x = toNum(x);
+    y = toNum(y);
+    return SuNum.div(toSuNum(x), toSuNum(y));
+}
+
+export function bitnot(x: any): number {
+    return ~toInt(x);
+}
+
+export function mod(x: any, y: any): number {
+    return toInt(x) % toInt(y);
+}
+
+export function lshift(x: any, y: any): number {
+    return toInt(x) << toInt(y);
+}
+
+export function rshift(x: any, y: any): number {
+    return toInt(x) >>> toInt(y);
+}
+
+export function bitand(x: any, y: any): number {
+    return toInt(x) & toInt(y);
+}
+
+export function bitor(x: any, y: any): number {
+    return toInt(x) | toInt(y);
+}
+
+export function bitxor(x: any, y: any): number {
+    return toInt(x) ^ toInt(y);
 }

--- a/runtime/rootclass.ts
+++ b/runtime/rootclass.ts
@@ -9,7 +9,7 @@ import { SuObject } from "./suobject";
 import { SuBoundMethod, isBlock } from "./suBoundMethod";
 import { mandatory, maxargs } from "./args";
 import { is } from "./ops";
-import { global } from "./global";
+import { globalLookup } from "./global";
 import * as util from "./utility";
 
 export class RootClass extends SuValue {
@@ -72,7 +72,10 @@ export class RootClass extends SuValue {
 
     lookup(this: any, method: string): SuCallable {
         let start = this.isClass() ? this : Object.getPrototypeOf(this);
-        return start[method] || global('Objects')[method];
+        if (method === 'New')
+            return start.New;
+        return (RootClass.prototype as any)[method] ||
+            start[method] || globalLookup('Objects', method);
     }
 
     // external methods

--- a/runtime/su.ts
+++ b/runtime/su.ts
@@ -17,7 +17,10 @@ import { display } from "./display";
 import { cmp } from "./cmp";
 import { global } from "./global";
 import { Strings } from "./builtin/strings";
-import { isString, coerceStr, toStr, is } from "./ops";
+import { isString, coerceStr, toStr, is, isnt, toNum, Num,
+    add, sub, mul, div, mod,
+    lshift, rshift,
+    bitnot, bitand, bitor, bitxor } from "./ops";
 const sm: any = Strings.prototype;
 import { Numbers } from "./builtin/numbers";
 const nm: any = Numbers.prototype;
@@ -32,12 +35,13 @@ import "./globals";
 import { mandatory } from "./args";
 import { Except } from "./builtin/except";
 
-type Num = number | SuNum;
-
 export { toStr } from "./ops";
 export { mandatory, maxargs } from "./args";
 export { blockreturn, blockReturnHandler, rethrowBlockReturn } from "./blockreturn";
-export { display, is, global, mapToOb, obToMap };
+export { display, is, isnt, global, mapToOb, obToMap,
+    add, sub, mul, div, mod,
+    lshift, rshift,
+    bitnot, bitand, bitor, bitxor };
 
 export const empty_object = new SuObject().Set_readonly();
 
@@ -53,7 +57,7 @@ export function put(ob: any, key: any, val: any): any {
 
 export function get(x: any, key: any): any {
     if (isString(x)) {
-        let i = toInt(key);
+        let i = toIntegerNumber(key);
         let n = x.length;
         if (i < 0) {
             i += n;
@@ -109,55 +113,12 @@ export function not(x: any): boolean {
     return !toBool(x);
 }
 
-export function bitnot(x: any): number {
-    return ~toInt(x);
-}
-
-function toInt(x: any): number {
+function toIntegerNumber(x: any): number {
     if (Number.isSafeInteger(x))
         return x;
     if (x instanceof SuNum && x.isInt())
         return x.toInt();
     throw new Error("can't convert " + type(x) + " to integer");
-}
-
-function toNum(x: any): Num {
-    if (typeof x === 'number' || x instanceof SuNum)
-        return x;
-    if (x === false || x === "")
-        return 0;
-    if (x === true)
-        return 1;
-    if (isString(x)) {
-        if (!/[.eE]/.test(x) && x.length < 14)
-            return parseInt(x);
-        let n = SuNum.parse(x);
-        if (n)
-            return n;
-    }
-    throw new Error("can't convert " + type(x) + " to number");
-}
-
-function toSuNum(x: number | SuNum): SuNum {
-    return (typeof x === 'number') ? SuNum.make(x) : x;
-}
-
-export function add(x: any, y: any): Num {
-    x = toNum(x);
-    y = toNum(y);
-    if (typeof x === 'number' && typeof y === 'number')
-        return x + y;
-    else
-        return SuNum.add(toSuNum(x), toSuNum(y));
-}
-
-export function sub(x: any, y: any): Num {
-    x = toNum(x);
-    y = toNum(y);
-    if (typeof x === 'number' && typeof y === 'number')
-        return x - y;
-    else
-        return SuNum.sub(toSuNum(x), toSuNum(y));
 }
 
 export function cat(x: any, y: any): string | Except {
@@ -167,49 +128,6 @@ export function cat(x: any, y: any): string | Except {
     if (y instanceof Except)
         return y.As(result);
     return result;
-}
-
-export function mul(x: any, y: any): Num {
-    x = toNum(x);
-    y = toNum(y);
-    if (typeof x === 'number' && typeof y === 'number')
-        return x * y;
-    else
-        return SuNum.mul(toSuNum(x), toSuNum(y));
-}
-
-export function div(x: any, y: any): SuNum {
-    x = toNum(x);
-    y = toNum(y);
-    return SuNum.div(toSuNum(x), toSuNum(y));
-}
-
-export function mod(x: any, y: any): number {
-    return toInt(x) % toInt(y);
-}
-
-export function lshift(x: any, y: any): number {
-    return toInt(x) << toInt(y);
-}
-
-export function rshift(x: any, y: any): number {
-    return toInt(x) >>> toInt(y);
-}
-
-export function bitand(x: any, y: any): number {
-    return toInt(x) & toInt(y);
-}
-
-export function bitor(x: any, y: any): number {
-    return toInt(x) | toInt(y);
-}
-
-export function bitxor(x: any, y: any): number {
-    return toInt(x) ^ toInt(y);
-}
-
-export function isnt(x: any, y: any): boolean {
-    return !is(x, y);
 }
 
 export function lt(x: any, y: any): boolean {

--- a/runtime/su.ts
+++ b/runtime/su.ts
@@ -15,7 +15,7 @@ import { SuDate } from "./sudate";
 import { type } from "./type";
 import { display } from "./display";
 import { cmp } from "./cmp";
-import { global } from "./global";
+import { global, globalLookup } from "./global";
 import { Strings } from "./builtin/strings";
 import { isString, coerceStr, toStr, is, isnt, toNum, Num,
     add, sub, mul, div, mod,
@@ -45,7 +45,7 @@ export { display, is, isnt, global, mapToOb, obToMap,
 
 export const empty_object = new SuObject().Set_readonly();
 
-export const root_class = RootClass.prototype;
+export const root_class = Object.freeze(RootClass.prototype);
 
 export function put(ob: any, key: any, val: any): any {
     if (ob instanceof SuValue)
@@ -349,9 +349,9 @@ function methodNotFound(ob: any, method: string): never {
 function getMethod(ob: any, method: string): any {
     let t = typeof ob;
     if (t === 'string')
-        return sm[method] || global('Strings')[method];
+        return sm[method] || globalLookup('Strings', method);
     if (t === 'number' || ob instanceof SuNum)
-        return nm[method] || global('Numbers')[method];
+        return nm[method] || globalLookup('Numbers', method);
     if (t === 'function')
         return fm[method];
     return ob instanceof SuValue

--- a/runtime/sudate.ts
+++ b/runtime/sudate.ts
@@ -7,7 +7,7 @@
 import * as assert from "./assert";
 import * as util from "./utility";
 import { SuValue, SuCallable } from "./suvalue";
-import { global } from "./global";
+import { globalLookup } from "./global";
 import { maxargs, mandatory } from "./args";
 
 const month = ["January", "February", "March", "April", "May", "June", "July",
@@ -39,7 +39,7 @@ export class SuDate extends SuValue {
     }
 
     lookup(this: any, method: string): SuCallable {
-        return this[method] || global('Dates')[method];
+        return this[method] || globalLookup('Dates', method);
     }
 
     timePart(): number {

--- a/runtime/suobject.ts
+++ b/runtime/suobject.ts
@@ -11,7 +11,7 @@ import { display } from "./display";
 import { is } from "./ops";
 import { mandatory, maxargs } from "./args";
 import { cmp } from "./cmp";
-import { global } from "./global";
+import { globalLookup } from "./global";
 import * as util from "./utility";
 
 import * as assert from "./assert";
@@ -378,7 +378,7 @@ export class SuObject extends SuValue {
     }
 
     lookup(this: any, method: string): SuCallable {
-        return this[method] || global('Objects')[method];
+        return this[method] || globalLookup('Objects', method);
     }
 
     toObject(): SuObject {

--- a/runtime/surecord.ts
+++ b/runtime/surecord.ts
@@ -4,7 +4,7 @@ import { SuCallable } from "./suvalue";
 import { mandatory, maxargs } from "./args";
 import { cmp } from "./cmp";
 import * as ops from "./ops";
-import { tryGlobal, global } from "./global";
+import { tryGlobal, globalLookup } from "./global";
 import * as assert from "./assert";
 
 export enum Status {
@@ -223,7 +223,7 @@ export class SuRecord extends SuObject {
     }
 
     public lookup(this: any, method: string): SuCallable {
-        return this[method] || global('Records')[method] || global('Objects')[method];
+        return this[method] || globalLookup('Records', method) || globalLookup('Objects', method);
     }
 
     public ["New?"](): boolean {


### PR DESCRIPTION
- Updated 'String?' function to handle Except
- Moved more basic operations to ops
- Changed the bit and mod operations to use the correct toInt
- Changed to avoid getting RootClass methods when look up user general methods
- Fixed the RootClass lookup method so that it lookups rootclass basic methods first, user defined class methods next and Objects methods at last and it handles "New" specially
- Added Seq and Seq? builtin functions
- Fixed so that Sequence will lookup Sequences methods