### PR TITLE
Fixed the Cannot read property 'valueOf' of undefined error 

### DIFF
--- a/runtime/suobject.ts
+++ b/runtime/suobject.ts
@@ -444,7 +444,7 @@ export class SuObject extends SuValue {
                 if (!SuObject.equals3(x.vec[i], y.vec[i], stack))
                     return false;
             for (let [k, v] of x.map)
-                if (!SuObject.equals3(v, y.map.get(k), stack))
+                if (!y.map.has(k) || !SuObject.equals3(v, y.map.get(k), stack))
                     return false;
             return true;
         } finally {

--- a/runtime/suobject_test.ts
+++ b/runtime/suobject_test.ts
@@ -73,7 +73,14 @@ assert.that(!ob2.equals(ob));
 ob2.put('a', 'alpha');
 assert.that(ob.equals(ob2));
 assert.that(ob2.equals(ob));
-
+ob.put('b', 'Beta');
+ob2.put('c', 'Test');
+assert.that(!ob.equals(ob2));
+assert.that(!ob2.equals(ob));
+ob.put('c', 'Test');
+ob2.put('b', 'Beta');
+assert.that(ob.equals(ob2));
+assert.that(ob2.equals(ob));
 // cmp
 function cmp(x: SuObject, y: SuObject, expected: number): void {
     assert.equal(x.compareTo(y), expected);


### PR DESCRIPTION
caused by comparing two objects with equal map lengths but different map member names