### PR TITLE
Fixed the error uninitialized member: 'ctrlKey' when mobile safari triggers the keydown event with non-standard CustomEvent type argument

### DIFF
--- a/runtime/builtin/UI/suEl.ts
+++ b/runtime/builtin/UI/suEl.ts
@@ -2,7 +2,7 @@ import * as util from '../../utility';
 import { isString, toStr } from "../../ops";
 import { SuNum } from "../../sunum";
 import { SuObject } from "../../suobject";
-import { display } from "../../su";
+import { display, mandatory, maxargs } from "../../su";
 import { SuValue, SuCallable } from "../../suvalue";
 import { isFunction } from '../../suBoundMethod';
 import { RootClass } from '../../rootclass';
@@ -57,6 +57,13 @@ export abstract class SuEl extends SuValue {
     put(key: any, val: any): void {
         let k = toStr(key);
         this.el[k] = convertSuValue(val);
+    }
+    GetDefault(key: any = mandatory(), def: any = mandatory()): any {
+        maxargs(2, arguments.length);
+        let val = this.get(key);
+        if (val !== undefined)
+            return val;
+        return def;
     }
 }
 
@@ -154,3 +161,18 @@ function isPureObject(value: any): boolean {
     }
     return Object.getPrototypeOf(value).isPrototypeOf(Object);
 }
+
+//BUILTIN SuEl.GetDefault(key, value)
+//GENERATED start
+(SuEl.prototype['GetDefault'] as any).$call = SuEl.prototype['GetDefault'];
+(SuEl.prototype['GetDefault'] as any).$callNamed = function ($named: any, key: any, value: any) {
+    maxargs(3, arguments.length);
+    ({ key = key, value = value } = $named);
+    return SuEl.prototype['GetDefault'].call(this, key, value);
+};
+(SuEl.prototype['GetDefault'] as any).$callAt = function (args: SuObject) {
+    return (SuEl.prototype['GetDefault'] as any).$callNamed.call(this, util.mapToOb(args.map), ...args.vec);
+};
+(SuEl.prototype['GetDefault'] as any).$params = 'key, value';
+//GENERATED end
+

--- a/runtime/builtin/UI/suNode.ts
+++ b/runtime/builtin/UI/suNode.ts
@@ -14,8 +14,12 @@ abstract class SuEventTarget extends SuEl {
         let event: string = toStr(_event);
         let useCapture: boolean = toBoolean(_useCapture);
         let listener = (e: Event) => {
-            let event = makeSuValue(e);
-            fn.$callNamed({ event: event });
+            // safari autofill
+            if (event === 'keydown' && e instanceof CustomEvent) {
+                return;
+            }
+            let suValue = makeSuValue(e);
+            fn.$callNamed({ event: suValue });
         };
         fn.$callbackWrapper = listener;
         this.el.addEventListener(event, listener, useCapture);
@@ -154,13 +158,6 @@ export class SuHtmlElMap extends SuValue {
             return false;
         return (key.el as any).su_window === this.suWin;
     }
-    GetDefault(key: any = mandatory(), def: any = mandatory()): any {
-        maxargs(2, arguments.length);
-        let val = this.get(key);
-        if (val !== undefined)
-            return val;
-        return def;
-    }
 }
 
 export function su_htmlElMap(_suWin: any): SuHtmlElMap {
@@ -228,20 +225,6 @@ if (typeof window !== 'undefined') {
     return (SuHtmlElMap.prototype['Member?'] as any).$callNamed.call(this, util.mapToOb(args.map), ...args.vec);
 };
 (SuHtmlElMap.prototype['Member?'] as any).$params = 'key';
-//GENERATED end
-
-//BUILTIN SuHtmlElMap.GetDefault(key, value)
-//GENERATED start
-(SuHtmlElMap.prototype['GetDefault'] as any).$call = SuHtmlElMap.prototype['GetDefault'];
-(SuHtmlElMap.prototype['GetDefault'] as any).$callNamed = function ($named: any, key: any, value: any) {
-    maxargs(3, arguments.length);
-    ({ key = key, value = value } = $named);
-    return SuHtmlElMap.prototype['GetDefault'].call(this, key, value);
-};
-(SuHtmlElMap.prototype['GetDefault'] as any).$callAt = function (args: SuObject) {
-    return (SuHtmlElMap.prototype['GetDefault'] as any).$callNamed.call(this, util.mapToOb(args.map), ...args.vec);
-};
-(SuHtmlElMap.prototype['GetDefault'] as any).$params = 'key, value';
 //GENERATED end
 
 //BUILTIN GetCurrentWindow()


### PR DESCRIPTION
Also added GetDefault method to suEl to make handling nonexistent members easier