### PR TITLE
Fix "Maximum call stack size exceeded" error on Safari (suggestion 34439)

### DIFF
--- a/runtime/pack.ts
+++ b/runtime/pack.ts
@@ -132,26 +132,16 @@ export class Pack {
         return SuNum.make(sign * coef, exp - 16);
     }
 
-    private static batch = 100000;
     private static unpackString(buf: ByteBuffer, pos: number, len: number) {
         if (len === 0)
             return "";
 
         let code;
         let s = "";
-        let start = 0;
-        let end = Math.min(Pack.batch, len);
-        // process in batch to avoid the "Maximum call stack size exceeded" error
-        // from the spread operator (...)
-        while (start < len) {
-            let c: number[] = [];
-            for (let i = start; i < end; i++) {
-                code = buf.get(pos + i);
-                c[i - start] = Pack.AsciiToUTF16.get(code) || code;
-            }
-            s += String.fromCharCode(...c);
-            start = end;
-            end = Math.min(end + Pack.batch, len);
+        let end = pos + len;
+        for (let i = pos; i < end; i++) {
+            code = buf.get(i);
+            s += String.fromCharCode(Pack.AsciiToUTF16.get(code) || code);
         }
         return s;
     }


### PR DESCRIPTION
Changed to build the unpacked string one char by one char instead of using String.fromCharCode with multiple input because it could cause 'Maximum call stack size exceeded' errors; Tested that the new version's speed is actually faster than the old version because the old String.fromCharCode uses recursive calls