### PR TITLE
34624  suneido.js - uninitialized member: "key" from suneido js client

### DIFF
--- a/runtime/builtin/UI/suNode.ts
+++ b/runtime/builtin/UI/suNode.ts
@@ -13,14 +13,17 @@ abstract class SuEventTarget extends SuEl {
         maxargs(3, arguments.length);
         let event: string = toStr(_event);
         let useCapture: boolean = toBoolean(_useCapture);
-        let listener = (e: Event) => {
-            // safari autofill
-            if (event === 'keydown' && e instanceof CustomEvent) {
-                return;
-            }
-            let suValue = makeSuValue(e);
-            fn.$callNamed({ event: suValue });
-        };
+        let listener = event === 'keydown' || event === 'keyup' ? (e: Event) => {
+                // browser autofill
+                if (!(e as KeyboardEvent).key) {
+                    return;
+                }
+                let suValue = makeSuValue(e);
+                fn.$callNamed({ event: suValue });
+            } : (e: Event) => {
+                let suValue = makeSuValue(e);
+                fn.$callNamed({ event: suValue });
+            };
         fn.$callbackWrapper = listener;
         this.el.addEventListener(event, listener, useCapture);
         return fn;


### PR DESCRIPTION
Changed to ignore the keydown/keyup events from autocomplete that don't have the expected attributes like "key" and "code"

Handles this here so that we don't need to check this in our every event listener